### PR TITLE
Add AI backlog refinement tools section

### DIFF
--- a/Backlog-Refinement.md
+++ b/Backlog-Refinement.md
@@ -1,7 +1,11 @@
 ## Backlog Refinement
 
-- [28 Product Backlog and Refinement Anti-Patterns](https://age-of-product.com/28-product-backlog-anti-patterns/) - by Stefan Wolpers. "The following article points at 28 of the most common product backlog anti-patterns – including the product backlog refinement process – that limit your Scrum team’s success."
+- [28 Product Backlog and Refinement Anti-Patterns](https://age-of-product.com/28-product-backlog-anti-patterns/) - by Stefan Wolpers. "The following article points at 28 of the most common product backlog anti-patterns – including the product backlog refinement process – that limit your Scrum team's success."
 
-- [Backlog/Roadmap Hygiene Tips](https://medium.com/@johnpcutler/backlog-roadmap-hygiene-tips-68364bb490cc) - by John Cutler. "The basic idea…bind as late as humanely possible. Don’t turn the 100-page specs of the past, into a mess of 1,000 Jira tickets. I prefer to keep backlogs VERY short, with only a few specific items decomposed at any particular time."
+- [Backlog/Roadmap Hygiene Tips](https://medium.com/@johnpcutler/backlog-roadmap-hygiene-tips-68364bb490cc) - by John Cutler. "The basic idea…bind as late as humanely possible. Don't turn the 100-page specs of the past, into a mess of 1,000 Jira tickets. I prefer to keep backlogs VERY short, with only a few specific items decomposed at any particular time."
 
 - [Product Backlog Refinement](https://www.mountaingoatsoftware.com/blog/product-backlog-refinement-grooming) - by Mike Cohn. "During a product backlog refinement meeting, the team and product owner discuss the top items on the product backlog. "
+
+## Tools
+
+- [Refine Backlog](https://refinebacklog.com) - API-first AI tool that automatically rewrites vague backlog items into well-structured user stories with acceptance criteria. Designed for CI/CD pipelines, GitHub Actions, and programmatic use — not just UI-based workflows.


### PR DESCRIPTION
The Backlog Refinement page currently only lists articles. Adding a Tools section to make it more useful for practitioners looking for software to support the process.

**Added:**
- [Refine Backlog](https://refinebacklog.com) — API-first AI tool for automated backlog refinement. Unique angle: designed for CI/CD pipelines and programmatic use, not just UI workflows.

Happy to add other tools to this section too if there are existing ones worth including.